### PR TITLE
Fix variable references bug

### DIFF
--- a/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/engine/engine.json
+++ b/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/engine/engine.json
@@ -167,22 +167,6 @@
       "defaultValue": 0
     },
     {
-      "key": "projectile_delta_x",
-      "label": "Projectile's Delta X",
-      "group": "Custom Projectiles",
-      "type" : "number",
-      "cType": "UBYTE",
-      "defaultValue": 1
-    },
-    {
-      "key": "projectile_delta_y",
-      "label": "Projectile's Delta Y",
-      "group": "Custom Projectiles",
-      "type" : "number",
-      "cType": "UBYTE",
-      "defaultValue": 1
-    },
-    {
       "key": "projectile_flags",
       "label": "Projectile Flags",
       "group": "Custom Projectiles",

--- a/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/engine/include/projectiles.h
+++ b/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/engine/include/projectiles.h
@@ -38,8 +38,8 @@ extern UINT8 projectile_phase;
 
 extern UBYTE projectile_flags;
 extern UBYTE projectile_launch_orbit;
-extern UBYTE projectile_delta_x;
-extern UBYTE projectile_delta_y;
+extern UWORD projectile_delta_x;
+extern UWORD projectile_delta_y;
 
 extern UBYTE projectile_hookshot_state;
 

--- a/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/engine/src/core/projectiles.c
+++ b/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/engine/src/core/projectiles.c
@@ -38,8 +38,8 @@ UBYTE projectile_phase;
 
 UBYTE projectile_flags;
 UBYTE projectile_launch_orbit;
-UBYTE projectile_delta_x;
-UBYTE projectile_delta_y;
+UWORD projectile_delta_x;
+UWORD projectile_delta_y;
 
 UBYTE projectile_hookshot_state;
 point16_t head_pos;

--- a/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/events/eventCustomProjectile.js
+++ b/plugins/CustomProjectile/4.1.2 and above/CustomProjectile/events/eventCustomProjectile.js
@@ -488,6 +488,8 @@ const compile = (input, helpers) => {
     getActorIndex,
     appendRaw,
     _compileSubScript,
+	getVariableAlias,
+	_setConstMemInt16,
   } = helpers;
   
   let flags = 0;
@@ -535,13 +537,13 @@ const compile = (input, helpers) => {
       break;
     case 1: // update variables
       flags |= UPDATE_VAR;
-      engineFieldSetToValue("projectile_delta_x", input.varX);
-      engineFieldSetToValue("projectile_delta_y", input.varY);
+	  _setConstMemInt16("projectile_delta_x", getVariableAlias(input.varX));
+      _setConstMemInt16("projectile_delta_y", getVariableAlias(input.varY));
       break;
     case 3: // a bit substandard?
       flags |= UPDATE_VAR;
-      engineFieldSetToValue("projectile_delta_x", input.varX);
-      engineFieldSetToValue("projectile_delta_y", input.varY);
+	  _setConstMemInt16("projectile_delta_x", getVariableAlias(input.varX));
+      _setConstMemInt16("projectile_delta_y", getVariableAlias(input.varY));
     case 2: // execute script
       const ref = _compileSubScript("projectile", input.script, "p_removal");
       const bank = `___bank_${ref}`;
@@ -588,8 +590,8 @@ const compile = (input, helpers) => {
       break;
 
     case type.custom:
-      engineFieldSetToValue("projectile_delta_x", input.customX);
-      engineFieldSetToValue("projectile_delta_y", input.customY);
+	  _setConstMemInt16("projectile_delta_x", getVariableAlias(input.customX));
+      _setConstMemInt16("projectile_delta_y", getVariableAlias(input.customY));
       break;
     
   }


### PR DESCRIPTION
When setting variable references to the engine from the custom event, use getVariableAlias (and setConstMemInt16) instead and also change the variable to UWORD because you can have more than 256 variables in script_memory.

Example project featuring the fix:
[Custom_projectile_example.zip](https://github.com/user-attachments/files/21724433/Custom_projectile_example.zip)
